### PR TITLE
remove validate - it doesn't work

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,3 @@ repos:
   rev: v1.31.0
   hooks:
     - id: terraform_fmt
-    - id: terraform_validate


### PR DESCRIPTION
it fails due to errors in example folders - see https://github.com/15five/terraform-aws-rds-cloudwatch-sns-alarms/runs/1645301775?check_suite_focus=true