### PR TITLE
Added datapoints_to_alarm requirement to free-storage alarm

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -110,6 +110,7 @@ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
   alarm_name          = "${var.name_prefix}${var.db_instance_ids[count.index]}-free_storage_space_threshold"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_periods
+  datapoints_to_alarm = var.datapoints_to_alarm
   metric_name         = "FreeStorageSpace"
   namespace           = "AWS/RDS"
   period              = var.period

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "period" {
   default     = "600"
 }
 
+variable "datapoints_to_alarm" {
+  description = "The number of datapoints that must be breaching to trigger the alarm."
+  type        = string
+  default     = "1"
+}
+
 variable "evaluation_periods" {
   description = "The number of periods over which data is compared to the specified threshold."
   type        = string


### PR DESCRIPTION
## what
* Added "datapionts_to_alarm" option to the free_storage_space_too_low alert to prevent it from being reverted to null 

## why
* This fixes the apply issue for the TF error/bug below

```
# TF PLAN - datapoints_to_alarm -> null ?
  # module.rds_mirror_heavy_alarms.aws_cloudwatch_metric_alarm.free_storage_space_too_low[0] will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
        actions_enabled           = true
        alarm_actions             = [
            "arn:aws:sns:us-east-1:#########:General-Alerts",
        ]
        alarm_description         = "Average database free storage space over last 5 minutes too low"
        alarm_name                = "mirror0-free_storage_space_threshold"
        arn                       = "arn:aws:cloudwatch:us-east-1::#########:alarm:mirror0-free_storage_space_threshold"
        comparison_operator       = "LessThanThreshold"
      - datapoints_to_alarm       = 1 -> null
        dimensions                = {
            "DBInstanceIdentifier" = "mirror0-heavy"
        }
        evaluation_periods        = 1
        id                        = "mirror0-heavy-free_storage_space_threshold"
        insufficient_data_actions = []
        metric_name               = "FreeStorageSpace"
        namespace                 = "AWS/RDS"
        ok_actions                = [
            "arn:aws:sns:us-east-1::#########:General-Alerts",
        ]
        period                    = 300
        statistic                 = "Average"
        tags                      = {}
        threshold                 = 11500000000
        treat_missing_data        = "missing"
    }


## TF APPLY ERROR
Error: Provider produced inconsistent final plan

When expanding the plan for
module.rds_mirror_alarms.aws_cloudwatch_metric_alarm.free_storage_space_too_low[0]
to include new values learned so far during apply, provider
"registry.terraform.io/-/aws" produced an invalid new value for .threshold:
was cty.NumberIntVal(1.15e+10), but now cty.NumberIntVal(1e+10).

This is a bug in the provider, which should be reported in the provider's own
issue tracker.

```

## references
* [Internal CI Link](https://app.circleci.com/pipelines/github/15five/fifteen5-terraform/978/workflows/670111de-293a-4eff-9b64-1cdd19237557/jobs/2688/parallel-runs/0/steps/0-107)